### PR TITLE
Remove throwable type from result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # java-result
-A Java implementation of a generic Result<VALUE, ERROR> type
+A Java implementation of a generic Result<VALUE> type
 
 ## LICENSE
 

--- a/src/main/java/io/github/mooninaut/result/AcceptedResult.java
+++ b/src/main/java/io/github/mooninaut/result/AcceptedResult.java
@@ -95,17 +95,17 @@ final class AcceptedResult<VAL> implements Result<VAL> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
     Result<OUT> exMap(EF mapper) {
-        return (Result<OUT>) ExceptionalFunctionWrapper.wrap(mapper).apply(get());
+        return ExceptionalFunctionWrapper.wrap(mapper).apply(get());
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
-        return (Result<OUT>) ExceptionalFunctionWrapper.wrapChecked(
-                mapper, inClass, outClass, outErrClass
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass) {
+        return ExceptionalFunctionWrapper.wrapChecked(
+                mapper, inClass, outClass
         ).apply(get());
     }
 

--- a/src/main/java/io/github/mooninaut/result/AcceptedResult.java
+++ b/src/main/java/io/github/mooninaut/result/AcceptedResult.java
@@ -94,14 +94,12 @@ final class AcceptedResult<VAL> implements Result<VAL> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
     Result<OUT> exMap(EF mapper) {
         return ExceptionalFunctionWrapper.wrap(mapper).apply(get());
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
     Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass) {
         return ExceptionalFunctionWrapper.wrapChecked(
@@ -110,7 +108,6 @@ final class AcceptedResult<VAL> implements Result<VAL> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <OUT, F extends Function<? super VAL, ? extends OUT>>
     Result<OUT> map(F mapper) {
         return Result.accept(mapper.apply(get()));

--- a/src/main/java/io/github/mooninaut/result/AcceptedResult.java
+++ b/src/main/java/io/github/mooninaut/result/AcceptedResult.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * limitations under the License.
  */
 
-final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> {
+final class AcceptedResult<VAL> implements Result<VAL> {
     ////// Fields //////
     private final VAL value;
 
@@ -62,15 +62,15 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> checkedCast(Class<OUT> type) throws ClassCastException {
+    public <OUT> Result<OUT> checkedCast(Class<OUT> type) throws ClassCastException {
         type.cast(get());
-        return (Result<OUT, ERR>) this;
+        return (Result<OUT>) this;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> uncheckedCast() {
-        return (Result<OUT, ERR>) this;
+    public <OUT> Result<OUT> uncheckedCast() {
+        return (Result<OUT>) this;
     }
 
     @Override
@@ -79,7 +79,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public ERR getException() {
+    public Throwable getException() {
         throw new IllegalStateException("Cannot get exception from accepted Result");
     }
 
@@ -96,15 +96,15 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMap(EF mapper) {
-        return (Result<OUT, Throwable>) ExceptionalFunctionWrapper.wrap(mapper).apply(get());
+    Result<OUT> exMap(EF mapper) {
+        return (Result<OUT>) ExceptionalFunctionWrapper.wrap(mapper).apply(get());
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
-        return (Result<OUT, Throwable>) ExceptionalFunctionWrapper.wrapChecked(
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
+        return (Result<OUT>) ExceptionalFunctionWrapper.wrapChecked(
                 mapper, inClass, outClass, outErrClass
         ).apply(get());
     }
@@ -112,7 +112,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, F extends Function<? super VAL, ? extends OUT>>
-    Result<OUT, ERR> map(F mapper) {
+    Result<OUT> map(F mapper) {
         return Result.accept(mapper.apply(get()));
     }
 
@@ -139,7 +139,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     public void throwRuntimeIfRejected() { }
 
     @Override
-    public Result<VAL, ERR> ifAccepted(Consumer<? super VAL> consumer) {
+    public Result<VAL> ifAccepted(Consumer<? super VAL> consumer) {
         if (isAccepted()) {
             consumer.accept(get());
         }
@@ -147,7 +147,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public Result<VAL, ERR> ifRejected(Consumer<? super ERR> rejector) {
+    public Result<VAL> ifRejected(Consumer<? super Throwable> rejector) {
         if (isRejected()) {
             rejector.accept(getException());
         }
@@ -155,7 +155,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public Result<VAL, ERR> then(Consumer<? super VAL> consumer, Consumer<? super ERR> rejector) {
+    public Result<VAL> then(Consumer<? super VAL> consumer, Consumer<? super Throwable> rejector) {
         if (isAccepted()) {
             consumer.accept(get());
         } else {
@@ -163,8 +163,9 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
         }
         return this;
     }
+
     @Override
-    public Result<VAL, ERR> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
+    public Result<VAL> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
         if (isAccepted()) {
             consumer.accept(get());
         } else {
@@ -172,24 +173,27 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
         }
         return this;
     }
+
     @Override
-    public Result<VAL, ERR> acceptOrElseThrow(Consumer<? super VAL> consumer) throws ERR {
+    public Result<VAL> acceptOrElseThrow(Consumer<? super VAL> consumer) throws Throwable {
         if (isRejected()) {
             throw getException();
         }
         consumer.accept(get());
         return this;
     }
+
     @Override
-    public Result<VAL, ERR> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
         if (isRejected()) {
             throw new RuntimeException(getException());
         }
         consumer.accept(get());
         return this;
     }
+
     @Override
-    public Result<VAL, ERR> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
         if (isAccepted()) {
             consumer.accept(get());
         } else {
@@ -208,7 +212,7 @@ final class AcceptedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AcceptedResult<?, ?> otherResult = (AcceptedResult<?, ?>) o;
+        AcceptedResult<?> otherResult = (AcceptedResult<?>) o;
         return Objects.equals(value, otherResult.value);
     }
 

--- a/src/main/java/io/github/mooninaut/result/CheckedExceptionalFunctionWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/CheckedExceptionalFunctionWrapperImpl.java
@@ -19,20 +19,18 @@ import java.util.Objects;
  * limitations under the License.
  */
 
-public class CheckedExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwable> extends
-        ExceptionalFunctionWrapperImpl<IN, OUT, ERR> {
+public class CheckedExceptionalFunctionWrapperImpl<IN, OUT> extends
+        ExceptionalFunctionWrapperImpl<IN, OUT> {
     private final Class<IN> inClass;
     private final Class<OUT> outClass;
-    private final Class<ERR> errClass;
+
     CheckedExceptionalFunctionWrapperImpl(
-            ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> ef,
+            ExceptionalFunction<? super IN, ? extends OUT> ef,
             Class<IN> inClass,
-            Class<OUT> outClass,
-            Class<ERR> errClass) {
+            Class<OUT> outClass) {
         super(ef);
         this.inClass = Objects.requireNonNull(inClass);
         this.outClass = Objects.requireNonNull(outClass);
-        this.errClass = Objects.requireNonNull(errClass);
     }
 
     @Override
@@ -43,8 +41,6 @@ public class CheckedExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwabl
             return result.checkedCast(outClass);
         }
 
-        errClass.cast(result.getException());
-
         return result;
     }
 
@@ -54,10 +50,6 @@ public class CheckedExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwabl
 
     public Class<OUT> getOutClass() {
         return outClass;
-    }
-
-    public Class<ERR> getErrClass() {
-        return errClass;
     }
 
     @Override
@@ -71,14 +63,13 @@ public class CheckedExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwabl
         if (!super.equals(o)) {
             return false;
         }
-        CheckedExceptionalFunctionWrapperImpl<?, ?, ?> that = (CheckedExceptionalFunctionWrapperImpl<?, ?, ?>) o;
+        CheckedExceptionalFunctionWrapperImpl<?, ?> that = (CheckedExceptionalFunctionWrapperImpl<?, ?>) o;
         return getInClass().equals(that.getInClass()) &&
-                getOutClass().equals(that.getOutClass()) &&
-                getErrClass().equals(that.getErrClass());
+                getOutClass().equals(that.getOutClass());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getInClass(), getOutClass(), getErrClass());
+        return Objects.hash(super.hashCode(), getInClass(), getOutClass());
     }
 }

--- a/src/main/java/io/github/mooninaut/result/CheckedExceptionalFunctionWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/CheckedExceptionalFunctionWrapperImpl.java
@@ -36,8 +36,8 @@ public class CheckedExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwabl
     }
 
     @Override
-    public Result<OUT, ERR> apply(IN in) throws ClassCastException {
-        Result<OUT, ERR> result = super.apply(inClass.cast(in));
+    public Result<OUT> apply(IN in) throws ClassCastException {
+        Result<OUT> result = super.apply(inClass.cast(in));
 
         if (result.isAccepted()) {
             return result.checkedCast(outClass);

--- a/src/main/java/io/github/mooninaut/result/CheckedExceptionalSupplierWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/CheckedExceptionalSupplierWrapperImpl.java
@@ -33,8 +33,8 @@ public class CheckedExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> e
     }
 
     @Override
-    public Result<OUT, ERR> get() throws ClassCastException {
-        Result<OUT, ERR> result = super.get();
+    public Result<OUT> get() throws ClassCastException {
+        Result<OUT> result = super.get();
 
         if (result.isAccepted()) {
             return result.checkedCast(outClass);

--- a/src/main/java/io/github/mooninaut/result/CheckedExceptionalSupplierWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/CheckedExceptionalSupplierWrapperImpl.java
@@ -19,17 +19,16 @@ import java.util.Objects;
  * limitations under the License.
  */
 
-public class CheckedExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> extends
-        ExceptionalSupplierWrapperImpl<OUT, ERR> {
+public class CheckedExceptionalSupplierWrapperImpl<OUT> extends
+        ExceptionalSupplierWrapperImpl<OUT> {
+
     private final Class<OUT> outClass;
-    private final Class<ERR> errClass;
+
     CheckedExceptionalSupplierWrapperImpl(
-            ExceptionalSupplier<? extends OUT, ? extends ERR> es,
-            Class<OUT> outClass,
-            Class<ERR> errClass) {
+            ExceptionalSupplier<? extends OUT> es,
+            Class<OUT> outClass) {
         super(es);
         this.outClass = Objects.requireNonNull(outClass);
-        this.errClass = Objects.requireNonNull(errClass);
     }
 
     @Override
@@ -40,17 +39,11 @@ public class CheckedExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> e
             return result.checkedCast(outClass);
         }
 
-        errClass.cast(result.getException());
-
         return result;
     }
 
     public Class<OUT> getOutClass() {
         return outClass;
-    }
-
-    public Class<ERR> getErrClass() {
-        return errClass;
     }
 
     @Override
@@ -64,13 +57,12 @@ public class CheckedExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> e
         if (!super.equals(o)) {
             return false;
         }
-        CheckedExceptionalSupplierWrapperImpl<?, ?> that = (CheckedExceptionalSupplierWrapperImpl<?, ?>) o;
-        return getOutClass().equals(that.getOutClass()) &&
-                getErrClass().equals(that.getErrClass());
+        CheckedExceptionalSupplierWrapperImpl<?> that = (CheckedExceptionalSupplierWrapperImpl<?>) o;
+        return getOutClass().equals(that.getOutClass());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getOutClass(), getErrClass());
+        return Objects.hash(super.hashCode(), getOutClass());
     }
 }

--- a/src/main/java/io/github/mooninaut/result/EmptyResult.java
+++ b/src/main/java/io/github/mooninaut/result/EmptyResult.java
@@ -101,18 +101,18 @@ final class EmptyResult<VAL> implements Result<VAL> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
     Result<OUT> exMap(
             EF mapper) {
-        return (Result<OUT>) ExceptionalFunctionWrapper.wrap(mapper).apply(null);
+        return ExceptionalFunctionWrapper.wrap(mapper).apply(null);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass) {
         return (Result<OUT>) ExceptionalFunctionWrapper
-                .wrapChecked(mapper, inClass, outClass, outErrClass);
+                .wrapChecked(mapper, inClass, outClass);
     }
 
     @Override

--- a/src/main/java/io/github/mooninaut/result/EmptyResult.java
+++ b/src/main/java/io/github/mooninaut/result/EmptyResult.java
@@ -22,17 +22,24 @@ import java.util.function.Function;
  * limitations under the License.
  */
 
-final class EmptyResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> {
+final class EmptyResult<VAL> implements Result<VAL> {
 
+    private enum Self {
+        INSTANCE;
+
+        private final EmptyResult<?> value = new EmptyResult<>();
+
+        @SuppressWarnings("unchecked")
+        public static <VAL> Result<VAL> getInstance() {
+            return (Result<VAL>) INSTANCE.value;
+        }
+    }
     private static final int HASH_CODE = Objects.hash(EmptyResult.class, null);
-
-    private static final Result<Void, ? extends Throwable> INSTANCE = new EmptyResult<>();
 
     private EmptyResult() { }
 
-    @SuppressWarnings("unchecked")
-    public static <VAL, ERR extends Throwable> Result<VAL, ERR> getInstance() {
-        return (Result<VAL, ERR>) INSTANCE;
+    public static <VAL> Result<VAL> getInstance() {
+        return Self.getInstance();
     }
 
     @Override
@@ -62,14 +69,14 @@ final class EmptyResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> 
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> checkedCast(Class<OUT> type) {
-        return (Result<OUT, ERR>) this;
+    public <OUT> Result<OUT> checkedCast(Class<OUT> type) {
+        return (Result<OUT>) this;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> uncheckedCast() {
-        return (Result<OUT, ERR>) this;
+    public <OUT> Result<OUT> uncheckedCast() {
+        return (Result<OUT>) this;
     }
 
     @Override
@@ -78,7 +85,7 @@ final class EmptyResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> 
     }
 
     @Override
-    public ERR getException() {
+    public Throwable getException() {
         throw new IllegalStateException("Cannot get exception from empty Result");
     }
 
@@ -95,21 +102,21 @@ final class EmptyResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> 
     @SuppressWarnings("unchecked")
     @Override
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMap(
+    Result<OUT> exMap(
             EF mapper) {
-        return (Result<OUT, Throwable>) ExceptionalFunctionWrapper.wrap(mapper).apply(null);
+        return (Result<OUT>) ExceptionalFunctionWrapper.wrap(mapper).apply(null);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
-        return (Result<OUT, Throwable>) ExceptionalFunctionWrapper
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
+        return (Result<OUT>) ExceptionalFunctionWrapper
                 .wrapChecked(mapper, inClass, outClass, outErrClass);
     }
 
     @Override
-    public <OUT, F extends Function<? super VAL, ? extends OUT>> Result<OUT, ERR> map(F mapper) {
+    public <OUT, F extends Function<? super VAL, ? extends OUT>> Result<OUT> map(F mapper) {
         return new AcceptedResult<>(mapper.apply(null));
     }
 
@@ -135,42 +142,42 @@ final class EmptyResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> 
     public void throwRuntimeIfRejected() throws RuntimeException { }
 
     @Override
-    public Result<VAL, ERR> ifAccepted(Consumer<? super VAL> consumer) {
+    public Result<VAL> ifAccepted(Consumer<? super VAL> consumer) {
         consumer.accept(null);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> ifRejected(Consumer<? super ERR> rejector) {
+    public Result<VAL> ifRejected(Consumer<? super Throwable> rejector) {
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> then(Consumer<? super VAL> consumer, Consumer<? super ERR> rejector) {
+    public Result<VAL> then(Consumer<? super VAL> consumer, Consumer<? super Throwable> rejector) {
         consumer.accept(null);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
+    public Result<VAL> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
         consumer.accept(null);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> acceptOrElseThrow(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrElseThrow(Consumer<? super VAL> consumer) {
         consumer.accept(null);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
         consumer.accept(null);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
         consumer.accept(null);
         return this;
     }

--- a/src/main/java/io/github/mooninaut/result/ExceptionalFunction.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalFunction.java
@@ -18,7 +18,7 @@ package io.github.mooninaut.result;
  */
 
 @FunctionalInterface
-public interface ExceptionalFunction<IN, OUT, ERR extends Throwable> {
+public interface ExceptionalFunction<IN, OUT> {
 
-    OUT apply(IN argument) throws ERR;
+    OUT apply(IN argument) throws Throwable;
 }

--- a/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapper.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapper.java
@@ -19,22 +19,21 @@ import java.util.function.Function;
  * limitations under the License.
  */
 
-public interface ExceptionalFunctionWrapper<IN, OUT, ERR extends Throwable> extends Function<IN, Result<OUT>> {
+public interface ExceptionalFunctionWrapper<IN, OUT> extends Function<IN, Result<OUT>> {
 
-    static <IN, OUT, ERR extends Throwable>
-    ExceptionalFunctionWrapperImpl<IN, OUT, ERR>
-    wrap(ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> ef) {
+    static <IN, OUT>
+    ExceptionalFunctionWrapperImpl<IN, OUT>
+    wrap(ExceptionalFunction<? super IN, ? extends OUT> ef) {
         return new ExceptionalFunctionWrapperImpl<>(ef);
     }
 
-    static <IN, OUT, ERR extends Throwable>
-    ExceptionalFunctionWrapper<IN, OUT, ERR>
+    static <IN, OUT>
+    ExceptionalFunctionWrapper<IN, OUT>
     wrapChecked(
-            ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> ef,
+            ExceptionalFunction<? super IN, ? extends OUT> ef,
             Class<IN> inClass,
-            Class<OUT> outClass,
-            Class<ERR> errClass) {
-        return new CheckedExceptionalFunctionWrapperImpl<>(ef, inClass, outClass, errClass);
+            Class<OUT> outClass) {
+        return new CheckedExceptionalFunctionWrapperImpl<>(ef, inClass, outClass);
     }
 
     @Override

--- a/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapper.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapper.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
  * limitations under the License.
  */
 
-public interface ExceptionalFunctionWrapper<IN, OUT, ERR extends Throwable> extends Function<IN, Result<OUT, ERR>> {
+public interface ExceptionalFunctionWrapper<IN, OUT, ERR extends Throwable> extends Function<IN, Result<OUT>> {
 
     static <IN, OUT, ERR extends Throwable>
     ExceptionalFunctionWrapperImpl<IN, OUT, ERR>
@@ -38,7 +38,7 @@ public interface ExceptionalFunctionWrapper<IN, OUT, ERR extends Throwable> exte
     }
 
     @Override
-    Result<OUT, ERR> apply(IN in);
+    Result<OUT> apply(IN in);
 
 
 }

--- a/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapperImpl.java
@@ -19,26 +19,25 @@ import java.util.Objects;
  * limitations under the License.
  */
 
-public class ExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwable> implements
-        ExceptionalFunctionWrapper<IN, OUT, ERR> {
-    private final ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exceptionalFunction;
+public class ExceptionalFunctionWrapperImpl<IN, OUT> implements
+        ExceptionalFunctionWrapper<IN, OUT> {
+    private final ExceptionalFunction<? super IN, ? extends OUT> exceptionalFunction;
 
-    ExceptionalFunctionWrapperImpl(ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exceptionalFunction) {
+    ExceptionalFunctionWrapperImpl(ExceptionalFunction<? super IN, ? extends OUT> exceptionalFunction) {
         this.exceptionalFunction = Objects.requireNonNull(exceptionalFunction);
     }
 
-    public ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> getExceptionalFunction() {
+    public ExceptionalFunction<? super IN, ? extends OUT> getExceptionalFunction() {
         return exceptionalFunction;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Result<OUT> apply(IN in) {
         try {
             return Result.accept(exceptionalFunction.apply(in));
         } catch (Throwable ex) {
             Exceptions.throwIfUnchecked(ex);
-            return new RejectedResult<>((ERR) ex);
+            return new RejectedResult<>(ex);
         }
     }
 
@@ -50,7 +49,7 @@ public class ExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwable> impl
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ExceptionalFunctionWrapperImpl<?, ?, ?> that = (ExceptionalFunctionWrapperImpl<?, ?, ?>) o;
+        ExceptionalFunctionWrapperImpl<?, ?> that = (ExceptionalFunctionWrapperImpl<?, ?>) o;
         return exceptionalFunction.equals(that.exceptionalFunction);
     }
 

--- a/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalFunctionWrapperImpl.java
@@ -33,7 +33,7 @@ public class ExceptionalFunctionWrapperImpl<IN, OUT, ERR extends Throwable> impl
 
     @SuppressWarnings("unchecked")
     @Override
-    public Result<OUT, ERR> apply(IN in) {
+    public Result<OUT> apply(IN in) {
         try {
             return Result.accept(exceptionalFunction.apply(in));
         } catch (Throwable ex) {

--- a/src/main/java/io/github/mooninaut/result/ExceptionalSupplier.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalSupplier.java
@@ -1,7 +1,7 @@
 package io.github.mooninaut.result;
 
 @FunctionalInterface
-public interface ExceptionalSupplier<OUT, ERR extends Throwable> {
+public interface ExceptionalSupplier<OUT> {
 
-    OUT get() throws ERR;
+    OUT get() throws Throwable;
 }

--- a/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapper.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapper.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
  * limitations under the License.
  */
 
-public interface ExceptionalSupplierWrapper<OUT, ERR extends Throwable> extends Supplier<Result<OUT, ERR>> {
+public interface ExceptionalSupplierWrapper<OUT, ERR extends Throwable> extends Supplier<Result<OUT>> {
 
     static <OUT, ERR extends Throwable>
     ExceptionalSupplierWrapper<OUT, ERR>
@@ -37,5 +37,5 @@ public interface ExceptionalSupplierWrapper<OUT, ERR extends Throwable> extends 
     }
 
     @Override
-    Result<OUT, ERR> get();
+    Result<OUT> get();
 }

--- a/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapper.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapper.java
@@ -19,21 +19,20 @@ import java.util.function.Supplier;
  * limitations under the License.
  */
 
-public interface ExceptionalSupplierWrapper<OUT, ERR extends Throwable> extends Supplier<Result<OUT>> {
+public interface ExceptionalSupplierWrapper<OUT> extends Supplier<Result<OUT>> {
 
-    static <OUT, ERR extends Throwable>
-    ExceptionalSupplierWrapper<OUT, ERR>
-    wrap(ExceptionalSupplier<? extends OUT, ? extends ERR> es) {
+    static <OUT>
+    ExceptionalSupplierWrapper<OUT>
+    wrap(ExceptionalSupplier<? extends OUT> es) {
         return new ExceptionalSupplierWrapperImpl<>(es);
     }
 
-    static <IN, OUT, ERR extends Throwable>
-    ExceptionalSupplierWrapper<OUT, ERR>
+    static <IN, OUT>
+    ExceptionalSupplierWrapper<OUT>
     wrapChecked(
-            ExceptionalSupplier<? extends OUT, ? extends ERR> es,
-            Class<OUT> outClass,
-            Class<ERR> errClass) {
-        return new CheckedExceptionalSupplierWrapperImpl<>(es, outClass, errClass);
+            ExceptionalSupplier<? extends OUT> es,
+            Class<OUT> outClass) {
+        return new CheckedExceptionalSupplierWrapperImpl<>(es, outClass);
     }
 
     @Override

--- a/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapperImpl.java
@@ -19,22 +19,21 @@ import java.util.Objects;
  * limitations under the License.
  */
 
-public class ExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> implements
-        ExceptionalSupplierWrapper<OUT, ERR> {
-    private final ExceptionalSupplier<? extends OUT, ? extends ERR> es;
+public class ExceptionalSupplierWrapperImpl<OUT> implements
+        ExceptionalSupplierWrapper<OUT> {
+    private final ExceptionalSupplier<? extends OUT> es;
 
-    ExceptionalSupplierWrapperImpl(ExceptionalSupplier<? extends OUT, ? extends ERR> es) {
+    ExceptionalSupplierWrapperImpl(ExceptionalSupplier<? extends OUT> es) {
         this.es = Objects.requireNonNull(es);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Result<OUT> get() {
         try {
             return Result.accept(es.get());
         } catch (Throwable ex) {
             Exceptions.throwIfUnchecked(ex);
-            return new RejectedResult<>((ERR) ex);
+            return new RejectedResult<>(ex);
         }
     }
 
@@ -46,7 +45,7 @@ public class ExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> implemen
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ExceptionalSupplierWrapperImpl<?, ?> that = (ExceptionalSupplierWrapperImpl<?, ?>) o;
+        ExceptionalSupplierWrapperImpl<?> that = (ExceptionalSupplierWrapperImpl<?>) o;
         return es.equals(that.es);
     }
 

--- a/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapperImpl.java
+++ b/src/main/java/io/github/mooninaut/result/ExceptionalSupplierWrapperImpl.java
@@ -29,7 +29,7 @@ public class ExceptionalSupplierWrapperImpl<OUT, ERR extends Throwable> implemen
 
     @SuppressWarnings("unchecked")
     @Override
-    public Result<OUT, ERR> get() {
+    public Result<OUT> get() {
         try {
             return Result.accept(es.get());
         } catch (Throwable ex) {

--- a/src/main/java/io/github/mooninaut/result/RejectedResult.java
+++ b/src/main/java/io/github/mooninaut/result/RejectedResult.java
@@ -92,15 +92,15 @@ final class RejectedResult<VAL> implements Result<VAL> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
     Result<OUT> exMap(EF mapper) {
         return (Result<OUT>) this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
+    public <OUT, EF extends ExceptionalFunction<? super VAL, ? extends OUT>>
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass) {
         return (Result<OUT>) this;
     }
 

--- a/src/main/java/io/github/mooninaut/result/RejectedResult.java
+++ b/src/main/java/io/github/mooninaut/result/RejectedResult.java
@@ -22,13 +22,13 @@ import java.util.function.Function;
  * limitations under the License.
  */
 
-final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ERR> {
+final class RejectedResult<VAL> implements Result<VAL> {
     ////// Fields //////
-    private final ERR throwable;
+    private final Throwable throwable;
 
     ////// Constructor ///////
 
-    RejectedResult(ERR throwable) {
+    RejectedResult(Throwable throwable) {
         this.throwable = throwable;
     }
 
@@ -60,14 +60,14 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> checkedCast(Class<OUT> type) {
-        return (Result<OUT, ERR>) this;
+    public <OUT> Result<OUT> checkedCast(Class<OUT> type) {
+        return (Result<OUT>) this;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <OUT> Result<OUT, ERR> uncheckedCast() {
-        return (Result<OUT, ERR>) this;
+    public <OUT> Result<OUT> uncheckedCast() {
+        return (Result<OUT>) this;
     }
 
     @Override
@@ -76,7 +76,7 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public ERR getException() {
+    public Throwable getException() {
         return throwable;
     }
 
@@ -86,29 +86,29 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public VAL orElseThrow() throws ERR {
+    public VAL orElseThrow() throws Throwable {
         throw throwable;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMap(EF mapper) {
-        return (Result<OUT, Throwable>) this;
+    Result<OUT> exMap(EF mapper) {
+        return (Result<OUT>) this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
-        return (Result<OUT, Throwable>) this;
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass) {
+        return (Result<OUT>) this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <OUT, F extends Function<? super VAL, ? extends OUT>>
-    Result<OUT, ERR> map(F mapper) {
-        return (Result<OUT, ERR>) this;
+    Result<OUT> map(F mapper) {
+        return (Result<OUT>) this;
     }
 
     @Override
@@ -127,7 +127,7 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public void throwIfRejected() throws ERR {
+    public void throwIfRejected() throws Throwable {
         throw throwable;
     }
 
@@ -137,36 +137,36 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
     }
 
     @Override
-    public Result<VAL, ERR> ifAccepted(Consumer<? super VAL> consumer) {
+    public Result<VAL> ifAccepted(Consumer<? super VAL> consumer) {
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> ifRejected(Consumer<? super ERR> rejector) {
+    public Result<VAL> ifRejected(Consumer<? super Throwable> rejector) {
         rejector.accept(throwable);
         return this;
     }
 
     @Override
-    public Result<VAL, ERR> then(Consumer<? super VAL> consumer, Consumer<? super ERR> rejector) {
+    public Result<VAL> then(Consumer<? super VAL> consumer, Consumer<? super Throwable> rejector) {
         rejector.accept(throwable);
         return this;
     }
     @Override
-    public Result<VAL, ERR> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
+    public Result<VAL> acceptOrElse(Consumer<? super VAL> consumer, VAL other) {
         consumer.accept(other);
         return this;
     }
     @Override
-    public Result<VAL, ERR> acceptOrElseThrow(Consumer<? super VAL> consumer) throws ERR {
+    public Result<VAL> acceptOrElseThrow(Consumer<? super VAL> consumer) throws Throwable {
         throw throwable;
     }
     @Override
-    public Result<VAL, ERR> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) {
         throw new RuntimeException(throwable);
     }
     @Override
-    public Result<VAL, ERR> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
+    public Result<VAL> acceptOrPrintStacktrace(Consumer<? super VAL> consumer) {
         throwable.printStackTrace();
         return this;
     }
@@ -180,7 +180,7 @@ final class RejectedResult<VAL, ERR extends Throwable> implements Result<VAL, ER
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RejectedResult<?, ?> otherResult = (RejectedResult<?, ?>) o;
+        RejectedResult<?> otherResult = (RejectedResult<?>) o;
         return throwable == otherResult.throwable;
     }
 

--- a/src/main/java/io/github/mooninaut/result/Result.java
+++ b/src/main/java/io/github/mooninaut/result/Result.java
@@ -24,30 +24,29 @@ import java.util.function.Function;
 
 /**
  * An immutable Result type that contains, if accepted, a result of type {@code <IN>} or {@code null},
- * or if rejected, a Throwable of type {@code <ERR>}.
+ * or if rejected, a Throwable.
  * @param <VAL> The type of the included value, if present.
- * @param <ERR> The type of the included Throwable, if present.
  */
-public interface Result<VAL, ERR extends Throwable> {
+public interface Result<VAL> {
 
     /**
      * Returns an empty Result. May or may not be a singleton.
      */
-    static <VAL, ERR extends Throwable> Result<VAL, ERR> empty() {
+    static <VAL> Result<VAL> empty() {
         return EmptyResult.getInstance();
     }
 
     /**
      * Creates and returns an accepted Result containing a value, {@code val}, of type {@code <IN>}.
      */
-    static <VAL, ERR extends Throwable> Result<VAL, ERR> accept(VAL val) {
+    static <VAL> Result<VAL> accept(VAL val) {
         return val == null ? EmptyResult.getInstance() : new AcceptedResult<>(val);
     }
 
     /**
      * Creates and returns a rejected Result containing an exception, {@code err}, of type {@code <ERR>}.
      */
-    static <VAL, ERR extends Throwable> Result<VAL, ERR> reject(ERR err) {
+    static <VAL, ERR extends Throwable> Result<VAL> reject(ERR err) {
         return new RejectedResult<>(Objects.requireNonNull(err));
     }
 
@@ -57,7 +56,7 @@ public interface Result<VAL, ERR extends Throwable> {
      * Otherwise, an accepted Result.
      */
     @SuppressWarnings("unchecked")
-    static <VAL, ERR extends Throwable> Result<VAL, ERR> from(Object o) {
+    static <VAL, ERR extends Throwable> Result<VAL> from(Object o) {
         if (o == null) {
             return EmptyResult.getInstance();
         }
@@ -68,7 +67,7 @@ public interface Result<VAL, ERR extends Throwable> {
     }
 
     @SuppressWarnings("unchecked")
-    static<VAL, ERR extends Throwable> Result<VAL, ERR> of(ExceptionalSupplier<VAL, ERR> es) {
+    static<VAL, ERR extends Throwable> Result<VAL> of(ExceptionalSupplier<VAL, ERR> es) {
         try {
             return accept(es.get());
         } catch (Throwable err) {
@@ -90,7 +89,7 @@ public interface Result<VAL, ERR extends Throwable> {
     // TODO: I'm almost tempted to return a Result<Result<OUT, ERR>, ClassCastException>
     // TODO: Is this even useful? When would you use it? Maybe in tests?
     // TODO: Maybe cast out but not err?
-    static <OUT, ERR extends Throwable> Result<OUT, ERR> ofChecked(
+    static <OUT, ERR extends Throwable> Result<OUT> ofChecked(
             ExceptionalSupplier<OUT, ERR> exceptionalSupplier,
             Class<OUT> outClass,
             Class<ERR> errClass) throws ClassCastException {
@@ -112,7 +111,7 @@ public interface Result<VAL, ERR extends Throwable> {
      * @param <OUT> The type to cast {@code in} to.
      * @return A result containing either {@code in} cast to type {@code <OUT>}, or a {@link ClassCastException}.
      */
-    static <IN, OUT> Result<OUT, ClassCastException> safeCast(IN in, Class<OUT> outClass) {
+    static <IN, OUT> Result<OUT> safeCast(IN in, Class<OUT> outClass) {
         try {
             return accept(outClass.cast(in));
         } catch (ClassCastException cce) {
@@ -126,7 +125,7 @@ public interface Result<VAL, ERR extends Throwable> {
      * @param <VAL> The type of {@code val}.
      * @return A Result containing either a non-null {@code val} or a {@link NullPointerException}.
      */
-    static <VAL> Result<VAL, NullPointerException> requireNonNull(VAL val) {
+    static <VAL> Result<VAL> requireNonNull(VAL val) {
         if (val == null) {
             return new RejectedResult<>(new NullPointerException());
         }
@@ -172,12 +171,12 @@ public interface Result<VAL, ERR extends Throwable> {
      * @param <OUT> The class to checkedCast to.
      * @return {@code this} if {@code <IN>} can be checkedCast to {@code OUT}.
      */
-    <OUT> Result<OUT, ERR> checkedCast(Class<OUT> type) throws ClassCastException;
+    <OUT> Result<OUT> checkedCast(Class<OUT> type) throws ClassCastException;
 
     /**
      * Performs an unchecked cast to {@code RESULT<OUT, ERR>}.
      */
-    <OUT> Result<OUT, ERR> uncheckedCast();
+    <OUT> Result<OUT> uncheckedCast();
 
     /**
      * Get this Result's value if this Result is accepted, or throws IllegalStateException.
@@ -187,7 +186,7 @@ public interface Result<VAL, ERR extends Throwable> {
     /**
      * Get this Result's Throwable if this result is Rejected, or throws IllegalStateException.
      */
-    ERR getException() throws IllegalStateException;
+    Throwable getException() throws IllegalStateException;
 
     /**
      * Get this Result's value if this Result is accepted, or {@code other} if it is rejected.
@@ -198,7 +197,7 @@ public interface Result<VAL, ERR extends Throwable> {
     /**
      * Get this Result's value if this Result is accepted, or throws the included Throwable if it is rejected.
      */
-    VAL orElseThrow() throws ERR;
+    VAL orElseThrow() throws Throwable;
 
     /**
      * Get this Result's value if this Result is accepted, or throws the included Throwable
@@ -209,7 +208,7 @@ public interface Result<VAL, ERR extends Throwable> {
     /**
      * Throws the included Throwable if it is rejected, otherwise does nothing.
      */
-    void throwIfRejected() throws ERR;
+    void throwIfRejected() throws Throwable;
 
     /**
      * Throws the included Throwable wrapped in a {@link RuntimeException} if it is rejected, otherwise does nothing.
@@ -227,10 +226,10 @@ public interface Result<VAL, ERR extends Throwable> {
      * @return If this Result accepted, the result of executing {@code mapper} on this Result's value, otherwise {@code this}
      */
     <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMap(EF mapper);
+    Result<OUT> exMap(EF mapper);
 
     <OUT, OUTERR extends Throwable, EF extends ExceptionalFunction<? super VAL, ? extends OUT, ? extends OUTERR>>
-    Result<OUT, Throwable> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass);
+    Result<OUT> exMapChecked(EF mapper, Class<VAL> inClass, Class<OUT> outClass, Class<OUTERR> outErrClass);
 
     /**
      * Calls {@code mapper} on IN and returns {@code Result<OUT,ERR>}
@@ -239,7 +238,7 @@ public interface Result<VAL, ERR extends Throwable> {
      * @return If this Result accepted, the Result of executing {@code mapper} on this Result's value, otherwise {@code this}
      */
     <OUT, F extends Function<? super VAL, ? extends OUT>>
-    Result<OUT, ERR> map(F mapper);
+    Result<OUT> map(F mapper);
 
     /**
      * Converts the Result to an {@link Optional}.
@@ -259,43 +258,43 @@ public interface Result<VAL, ERR extends Throwable> {
      * If this Result is accepted, feed the included value to the supplied {@link Consumer}, otherwise, do nothing.
      * Chainable.
      */
-    Result<VAL, ERR> ifAccepted(Consumer<? super VAL> consumer);
+    Result<VAL> ifAccepted(Consumer<? super VAL> consumer);
 
     /**
      * If this Result is rejected, feed the included {@link Throwable} to the supplied {@link Consumer}, otherwise, do nothing.
      * Chainable.
      */
-    Result<VAL, ERR> ifRejected(Consumer<? super ERR> rejector);
+    Result<VAL> ifRejected(Consumer<? super Throwable> rejector);
 
     /**
      * Feed this Result's value or {@link Throwable} to the appropriate {@link Consumer}.
      * Chainable.
      */
-    Result<VAL, ERR> then(Consumer<? super VAL> consumer, Consumer<? super ERR> rejector);
+    Result<VAL> then(Consumer<? super VAL> consumer, Consumer<? super Throwable> rejector);
 
     /**
      * Feed this Result's value to the supplied {@link Consumer} if it is present, otherwise feed {@code other} to it.
      * Chainable.
      */
-    Result<VAL, ERR> acceptOrElse(Consumer<? super VAL> consumer, VAL other);
+    Result<VAL> acceptOrElse(Consumer<? super VAL> consumer, VAL other);
 
     /**
      * Feed this Result's value to the supplied {@link Consumer} if it is present, otherwise throw this Result's {@link Throwable}.
      * Chainable.
      */
-    Result<VAL, ERR> acceptOrElseThrow(Consumer<? super VAL> consumer) throws ERR;
+    Result<VAL> acceptOrElseThrow(Consumer<? super VAL> consumer) throws Throwable;
 
     /**
      * Feed this Result's value to the supplied {@link Consumer} if it is present, otherwise
      * throw this Result's {@link Throwable} wrapped in a {@link RuntimeException}.
      * Chainable.
      */
-    Result<VAL, ERR> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) throws RuntimeException;
+    Result<VAL> acceptOrElseThrowRuntime(Consumer<? super VAL> consumer) throws RuntimeException;
 
     /**
      * Feed this Result's value to the supplied {@link Consumer} if it is present, otherwise
      * print the stack trace associated with this Result's {@link Throwable} to standard error.
      * Chainable.
      */
-    Result<VAL, ERR> acceptOrPrintStacktrace(Consumer<? super VAL> consumer);
+    Result<VAL> acceptOrPrintStacktrace(Consumer<? super VAL> consumer);
 }

--- a/src/main/java/io/github/mooninaut/result/Results.java
+++ b/src/main/java/io/github/mooninaut/result/Results.java
@@ -33,19 +33,18 @@ public interface Results {
      * @param exFunc A function from {@code <IN>} to {@code <OUT>}
      * @param <IN> The value type of an existing {@code Result}.
      * @param <OUT> The value type of the new {@code Result} returned by the lambda.
-     * @param <ERR> The type of the exception possibly thrown by the mapping function.
      * @return A wrapped function that takes {@code Result<IN, Throwable>} and returns {@code Result<OUT, Throwable>}.
      */
-    static <IN, OUT, ERR extends Throwable>
-    Function<Result<IN>, Result<OUT>> exMapper(ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exFunc) {
+    static <IN, OUT>
+    Function<Result<IN>, Result<OUT>> exMapper(ExceptionalFunction<? super IN, ? extends OUT> exFunc) {
         return result -> result.exMap(exFunc);
     }
 
-    static <IN, OUT, ERR extends Throwable>
+    static <IN, OUT>
     Function<Result<IN>, Result<OUT>> exMapperChecked(
-            ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exFunc,
-            Class<IN> inClass, Class<OUT> outClass, Class<ERR> errClass) {
-        return result -> result.exMapChecked(exFunc, inClass, outClass, errClass);
+            ExceptionalFunction<? super IN, ? extends OUT> exFunc,
+            Class<IN> inClass, Class<OUT> outClass) {
+        return result -> result.exMapChecked(exFunc, inClass, outClass);
     }
 
     /**
@@ -56,10 +55,9 @@ public interface Results {
      * @param func A function from {@code <IN>} to {@code <OUT>}
      * @param <VAL> The value type of an existing {@code Result}.
      * @param <VAL2> The value type of the new {@code Result} returned by the lambda.
-     * @param <ERR> The type of the exception possibly thrown by the mapping function.
      * @return A wrapped function that takes {@code Result<IN, Throwable>} and returns {@code Result<OUT, Throwable>}.
      */
-    static <VAL, VAL2, ERR extends Throwable>
+    static <VAL, VAL2>
     Function<Result<VAL>, Result<VAL2>> mapper(Function<? super VAL, ? extends VAL2> func) {
         return result -> result.map(func);
     }

--- a/src/main/java/io/github/mooninaut/result/Results.java
+++ b/src/main/java/io/github/mooninaut/result/Results.java
@@ -37,12 +37,12 @@ public interface Results {
      * @return A wrapped function that takes {@code Result<IN, Throwable>} and returns {@code Result<OUT, Throwable>}.
      */
     static <IN, OUT, ERR extends Throwable>
-    Function<Result<IN, ? extends Throwable>, Result<OUT, Throwable>> exMapper(ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exFunc) {
+    Function<Result<IN>, Result<OUT>> exMapper(ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exFunc) {
         return result -> result.exMap(exFunc);
     }
 
     static <IN, OUT, ERR extends Throwable>
-    Function<Result<IN, ? extends Throwable>, Result<OUT, Throwable>> exMapperChecked(
+    Function<Result<IN>, Result<OUT>> exMapperChecked(
             ExceptionalFunction<? super IN, ? extends OUT, ? extends ERR> exFunc,
             Class<IN> inClass, Class<OUT> outClass, Class<ERR> errClass) {
         return result -> result.exMapChecked(exFunc, inClass, outClass, errClass);
@@ -60,63 +60,63 @@ public interface Results {
      * @return A wrapped function that takes {@code Result<IN, Throwable>} and returns {@code Result<OUT, Throwable>}.
      */
     static <VAL, VAL2, ERR extends Throwable>
-    Function<Result<VAL, ERR>, Result<VAL2, ERR>> mapper(Function<? super VAL, ? extends VAL2> func) {
+    Function<Result<VAL>, Result<VAL2>> mapper(Function<? super VAL, ? extends VAL2> func) {
         return result -> result.map(func);
     }
 
     /**
      * Map and filter a Stream of Results to a Stream of just values.
      */
-    static <VAL> Stream<VAL> valueStream(Stream<Result<VAL, ? extends Throwable>> stream) {
+    static <VAL> Stream<VAL> valueStream(Stream<Result<VAL>> stream) {
         return stream.filter(Result::isAccepted).map(Result::get);
     }
 
     /**
      * Map and filter a Collection of Results to a Stream of just values.
      */
-    static <VAL> Stream<VAL> valueStream(Collection<Result<VAL, ? extends Throwable>> collection) {
+    static <VAL> Stream<VAL> valueStream(Collection<Result<VAL>> collection) {
         return valueStream(collection.stream());
     }
 
     /**
      * Map and filter a Stream of Results to a Stream of just Throwables.
      */
-    static <VAL> Stream<? extends Throwable> exceptionStream(Stream<Result<VAL, ? extends Throwable>> stream) {
+    static <VAL> Stream<? extends Throwable> exceptionStream(Stream<Result<VAL>> stream) {
         return stream.filter(Result::isRejected).map(Result::getException);
     }
 
     /**
      * Map and filter a Collection of Results to a Stream of just Throwables.
      */
-    static <VAL> Stream<? extends Throwable> exceptionStream(Collection<Result<VAL, ? extends Throwable>> collection) {
+    static <VAL> Stream<? extends Throwable> exceptionStream(Collection<Result<VAL>> collection) {
         return exceptionStream(collection.stream());
     }
 
     /**
      * Map a Stream of Results to a Stream of Optionals.
      */
-    static <VAL> Stream<Optional<VAL>> optionalStream(Stream<Result<VAL, ? extends Throwable>> stream) {
+    static <VAL> Stream<Optional<VAL>> optionalStream(Stream<Result<VAL>> stream) {
         return stream.map(Result::toNullableOptional);
     }
 
     /**
      * Map a Collection of Results to a Stream of Optionals.
      */
-    static <VAL> Stream<Optional<VAL>> optionalStream(Collection<Result<VAL, ? extends Throwable>> collection) {
+    static <VAL> Stream<Optional<VAL>> optionalStream(Collection<Result<VAL>> collection) {
         return optionalStream(collection.stream());
     }
 
     /**
      * Transforms a Stream of Results to a single SplitStream containing a stream of values and a Stream of Throwables.
      */
-    static <VAL, ERR extends Throwable> SplitStream<VAL, ERR> splitStream(Stream<Result<VAL, ERR>> stream) {
-        return stream.collect(new SplitCollectorImpl<>());
+    static <VAL> SplitStream<VAL> splitStream(Stream<Result<VAL>> stream) {
+        return stream.collect(SplitCollectorImpl.collector());
     }
 
     /**
      * Transforms a Collection of Results to a single SplitStream containing a stream of values and a Stream of Throwables.
      */
-    static <VAL, ERR extends Throwable> SplitStream<VAL, ERR> splitStream(Collection<Result<VAL, ERR>> collection) {
+    static <VAL> SplitStream<VAL> splitStream(Collection<Result<VAL>> collection) {
         return splitStream(collection.stream());
     }
 }

--- a/src/main/java/io/github/mooninaut/result/SplitCollector.java
+++ b/src/main/java/io/github/mooninaut/result/SplitCollector.java
@@ -4,7 +4,7 @@ import io.github.mooninaut.result.SplitStream.Builder;
 
 import java.util.stream.Collector;
 
-public interface SplitCollector<VAL, ERR extends Throwable>
-        extends Collector<Result<VAL, ERR>, Builder<VAL, ERR>, SplitStream<VAL, ERR>> {
+public interface SplitCollector<VAL>
+        extends Collector<Result<VAL>, Builder<VAL>, SplitStream<VAL>> {
 
 }

--- a/src/main/java/io/github/mooninaut/result/SplitCollectorImpl.java
+++ b/src/main/java/io/github/mooninaut/result/SplitCollectorImpl.java
@@ -38,7 +38,7 @@ public class SplitCollectorImpl<VAL>
         }
     }
 
-    public static <VAL, ERR extends Throwable> SplitCollector<VAL> collector() {
+    public static <VAL> SplitCollector<VAL> collector() {
         return Self.getInstance();
     }
 
@@ -53,7 +53,7 @@ public class SplitCollectorImpl<VAL>
     public BiConsumer<SplitStream.Builder<VAL>, Result<VAL>> accumulator() {
         return SplitCollectorImpl::accumulate;
     }
-    private static <VAL, ERR extends Throwable> void accumulate(SplitStream.Builder<VAL> builders, Result<VAL> value) {
+    private static <VAL> void accumulate(SplitStream.Builder<VAL> builders, Result<VAL> value) {
         builders.add(value);
     }
 
@@ -61,7 +61,7 @@ public class SplitCollectorImpl<VAL>
     public BinaryOperator<SplitStream.Builder<VAL>> combiner() {
         return SplitCollectorImpl::combine;
     }
-    private static <VAL, ERR extends Throwable> SplitStream.Builder<VAL> combine(
+    private static <VAL> SplitStream.Builder<VAL> combine(
             SplitStream.Builder<VAL> one,
             SplitStream.Builder<VAL> two) {
         return one.append(two);
@@ -71,7 +71,7 @@ public class SplitCollectorImpl<VAL>
     public Function<SplitStream.Builder<VAL>, SplitStream<VAL>> finisher() {
         return SplitCollectorImpl::finish;
     }
-    private static <VAL, ERR extends Throwable> SplitStream<VAL> finish(SplitStream.Builder<VAL> builders) {
+    private static <VAL> SplitStream<VAL> finish(SplitStream.Builder<VAL> builders) {
         return builders.build();
     }
 

--- a/src/main/java/io/github/mooninaut/result/SplitCollectorImpl.java
+++ b/src/main/java/io/github/mooninaut/result/SplitCollectorImpl.java
@@ -24,54 +24,54 @@ import java.util.function.Supplier;
  * limitations under the License.
  */
 
-public class SplitCollectorImpl<VAL, ERR extends Throwable>
-        implements SplitCollector<VAL, ERR> {
+public class SplitCollectorImpl<VAL>
+        implements SplitCollector<VAL> {
 
-    enum Self {
+    private enum Self {
         INSTANCE;
 
-        private final SplitCollectorImpl<?, ?> value = new SplitCollectorImpl<>();
+        private final SplitCollectorImpl<?> value = new SplitCollectorImpl<>();
 
         @SuppressWarnings("unchecked")
-        public static <VAL, ERR extends Throwable> SplitCollector<VAL, ERR> getInstance() {
-            return (SplitCollector<VAL, ERR>) INSTANCE.value;
+        public static <VAL> SplitCollector<VAL> getInstance() {
+            return (SplitCollector<VAL>) INSTANCE.value;
         }
     }
 
-    public static <VAL, ERR extends Throwable> SplitCollector<VAL, ERR> collector() {
+    public static <VAL, ERR extends Throwable> SplitCollector<VAL> collector() {
         return Self.getInstance();
     }
 
     private SplitCollectorImpl() { }
 
     @Override
-    public Supplier<SplitStream.Builder<VAL, ERR>> supplier() {
+    public Supplier<SplitStream.Builder<VAL>> supplier() {
         return SplitStream.Builder::new;
     }
 
     @Override
-    public BiConsumer<SplitStream.Builder<VAL, ERR>, Result<VAL, ERR>> accumulator() {
+    public BiConsumer<SplitStream.Builder<VAL>, Result<VAL>> accumulator() {
         return SplitCollectorImpl::accumulate;
     }
-    private static <VAL, ERR extends Throwable> void accumulate(SplitStream.Builder<VAL, ERR> builders, Result<VAL, ERR> value) {
+    private static <VAL, ERR extends Throwable> void accumulate(SplitStream.Builder<VAL> builders, Result<VAL> value) {
         builders.add(value);
     }
 
     @Override
-    public BinaryOperator<SplitStream.Builder<VAL, ERR>> combiner() {
+    public BinaryOperator<SplitStream.Builder<VAL>> combiner() {
         return SplitCollectorImpl::combine;
     }
-    private static <VAL, ERR extends Throwable> SplitStream.Builder<VAL, ERR> combine(
-            SplitStream.Builder<VAL, ERR> one,
-            SplitStream.Builder<VAL, ERR> two) {
+    private static <VAL, ERR extends Throwable> SplitStream.Builder<VAL> combine(
+            SplitStream.Builder<VAL> one,
+            SplitStream.Builder<VAL> two) {
         return one.append(two);
     }
 
     @Override
-    public Function<SplitStream.Builder<VAL, ERR>, SplitStream<VAL, ERR>> finisher() {
+    public Function<SplitStream.Builder<VAL>, SplitStream<VAL>> finisher() {
         return SplitCollectorImpl::finish;
     }
-    private static <VAL, ERR extends Throwable> SplitStream<VAL, ERR> finish(SplitStream.Builder<VAL, ERR> builders) {
+    private static <VAL, ERR extends Throwable> SplitStream<VAL> finish(SplitStream.Builder<VAL> builders) {
         return builders.build();
     }
 

--- a/src/main/java/io/github/mooninaut/result/SplitStream.java
+++ b/src/main/java/io/github/mooninaut/result/SplitStream.java
@@ -23,14 +23,14 @@ public class SplitStream<VAL> {
     private final Stream<VAL> valueStream;
     private final Stream<Throwable> exceptionStream;
 
-    SplitStream(Stream.Builder<VAL> valueBuilder, Stream.Builder<Throwable> exceptionBuilder) {
+    SplitStream(Stream.Builder<VAL> valueBuilder, Stream.Builder<Throwable> throwableBuilder) {
         valueStream = valueBuilder.build();
-        exceptionStream = exceptionBuilder.build();
+        exceptionStream = throwableBuilder.build();
     }
 
-    SplitStream(Stream<VAL> valueStream, Stream<Throwable> errorStream) {
+    SplitStream(Stream<VAL> valueStream, Stream<Throwable> throwableStream) {
         this.valueStream = valueStream;
-        this.exceptionStream = errorStream;
+        this.exceptionStream = throwableStream;
     }
 
     public Stream<VAL> getValueStream() {
@@ -41,7 +41,7 @@ public class SplitStream<VAL> {
         return exceptionStream;
     }
 
-    public static <VAL, ERR extends Throwable> Builder<VAL> builder() {
+    public static <VAL> Builder<VAL> builder() {
         return new Builder<>();
     }
 

--- a/src/main/java/io/github/mooninaut/result/SplitStream.java
+++ b/src/main/java/io/github/mooninaut/result/SplitStream.java
@@ -19,16 +19,16 @@ import java.util.stream.Stream;
  * limitations under the License.
  */
 
-public class SplitStream<VAL, ERR extends Throwable> {
+public class SplitStream<VAL> {
     private final Stream<VAL> valueStream;
-    private final Stream<ERR> exceptionStream;
+    private final Stream<Throwable> exceptionStream;
 
-    SplitStream(Stream.Builder<VAL> valueBuilder, Stream.Builder<ERR> exceptionBuilder) {
+    SplitStream(Stream.Builder<VAL> valueBuilder, Stream.Builder<Throwable> exceptionBuilder) {
         valueStream = valueBuilder.build();
         exceptionStream = exceptionBuilder.build();
     }
 
-    SplitStream(Stream<VAL> valueStream, Stream<ERR> errorStream) {
+    SplitStream(Stream<VAL> valueStream, Stream<Throwable> errorStream) {
         this.valueStream = valueStream;
         this.exceptionStream = errorStream;
     }
@@ -37,50 +37,50 @@ public class SplitStream<VAL, ERR extends Throwable> {
         return valueStream;
     }
 
-    public Stream<ERR> getExceptionStream() {
+    public Stream<Throwable> getExceptionStream() {
         return exceptionStream;
     }
 
-    public static <VAL, ERR extends Throwable> Builder<VAL, ERR> builder() {
+    public static <VAL, ERR extends Throwable> Builder<VAL> builder() {
         return new Builder<>();
     }
 
-    public static class Builder<VAL, ERR extends Throwable> {
+    public static class Builder<VAL> {
         private final Stream.Builder<VAL> valueBuilder;
-        private final Stream.Builder<ERR> exceptionBuilder;
+        private final Stream.Builder<Throwable> exceptionBuilder;
 
         public Builder() {
             valueBuilder = Stream.builder();
             exceptionBuilder = Stream.builder();
         }
 
-        public Builder(Stream.Builder<VAL> valueBuilder, Stream.Builder<ERR> exceptionBuilder) {
+        public Builder(Stream.Builder<VAL> valueBuilder, Stream.Builder<Throwable> exceptionBuilder) {
             this.valueBuilder = valueBuilder;
             this.exceptionBuilder = exceptionBuilder;
         }
 
-        public SplitStream<VAL, ERR> build() {
+        public SplitStream<VAL> build() {
             return new SplitStream<>(valueBuilder, exceptionBuilder);
         }
 
-        public SplitStream.Builder<VAL, ERR> append(SplitStream.Builder<VAL, ERR> other) {
-            SplitStream<VAL, ERR> otherStream = other.build();
+        public SplitStream.Builder<VAL> append(SplitStream.Builder<VAL> other) {
+            SplitStream<VAL> otherStream = other.build();
             otherStream.getValueStream().forEach(valueBuilder);
             otherStream.getExceptionStream().forEach(exceptionBuilder);
             return this;
         }
 
-        public Builder<VAL, ERR> addValue(VAL value) {
+        public Builder<VAL> addValue(VAL value) {
             valueBuilder.add(value);
             return this;
         }
 
-        public Builder<VAL, ERR> addException(ERR error) {
+        public Builder<VAL> addException(Throwable error) {
             exceptionBuilder.add(error);
             return this;
         }
 
-        public Builder<VAL, ERR> add(Result<VAL, ERR> result) {
+        public Builder<VAL> add(Result<VAL> result) {
             if (result.isAccepted()) {
                 valueBuilder.add(result.get());
             } else {

--- a/src/test/java/io/github/mooninaut/result/ResultTest.java
+++ b/src/test/java/io/github/mooninaut/result/ResultTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -33,7 +32,7 @@ public class ResultTest {
                     .map(Result::requireNonNull),
                 Stream.of("badURL").map(ExceptionalFunctionWrapper.wrap(URL::new))
             )
-                .map(Results.exMapperChecked(URL::toURI, URL.class, URI.class, URISyntaxException.class))
+                .map(Results.exMapperChecked(URL::toURI, URL.class, URI.class))
                 .map(Results.mapper(Paths::get))
                 .map(Results.exMapper(Files::newBufferedReader))
                 .map(Results.exMapper(BufferedReader::lines))

--- a/src/test/java/io/github/mooninaut/result/ResultTest.java
+++ b/src/test/java/io/github/mooninaut/result/ResultTest.java
@@ -16,17 +16,17 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ResultTest {
 
     @Test
     public void fileReadTest() {
         List<String> fileNameList = Arrays.asList("files/file1.txt", "files/file2.txt", "files/doesnotexist");
-        SplitStream<String, Throwable> splitStream = Results.splitStream(
+        SplitStream<String> splitStream = Results.splitStream(
             Stream.concat(
                 fileNameList.stream()
                     .map(fileName -> ResultTest.class.getClassLoader().getResource(fileName))
@@ -53,18 +53,6 @@ public class ResultTest {
     }
 
     @Test
-    public void cannotRejectNonThrowable() {
-        boolean success;
-        try {
-            Result.reject((Throwable) (Object) "not a throwable");
-            success = false;
-        } catch (Throwable err) {
-            success = err instanceof ClassCastException;
-        }
-        assertTrue("Can reject non-Throwable", success);
-    }
-
-    @Test
     public void canAcceptThrowable() { // don't know why you'd want to but there's no law against it
         boolean success;
         try {
@@ -79,14 +67,13 @@ public class ResultTest {
 
     @Test
     public void cannotRejectNull() {
-        boolean success;
+        Throwable throwable = null;
         try {
             Result.reject(null);
-            success = false;
         } catch (Throwable err) {
-            success = err instanceof NullPointerException;
+            throwable = err;
         }
-        assertTrue("Can reject null", success);
+        assertTrue("Can reject null", throwable instanceof NullPointerException);
     }
 
     @Test
@@ -104,7 +91,7 @@ public class ResultTest {
 
     @Test
     public void ofCatchesCorrectly() {
-        Result<Object, Throwable> result = null;
+        Result<Object> result = null;
         Throwable throwable = new Throwable();
         try {
             result = Result.of(() -> { throw throwable; });
@@ -118,7 +105,7 @@ public class ResultTest {
 
     @Test
     public void ofReturnsEmptyCorrectly() {
-        Result<Object, Throwable> result = Result.of(() -> null);
+        Result<Object> result = Result.of(() -> null);
 
         assertTrue(result.isAccepted());
         assertTrue(result.isEmpty());
@@ -128,7 +115,7 @@ public class ResultTest {
     @Test
     public void ofReturnsAcceptedCorrectly() {
         Object o = new Object();
-        Result<Object, Throwable> result = Result.of(() -> o);
+        Result<Object> result = Result.of(() -> o);
 
         assertTrue(result.isAccepted());
         assertTrue(result.isPresent());
@@ -150,20 +137,20 @@ public class ResultTest {
     @Test
     public void safeCastAcceptsValidCast() {
         String string = "a string";
-        Result<CharSequence, ClassCastException> result = Result.safeCast(string, CharSequence.class);
+        Result<CharSequence> result = Result.safeCast(string, CharSequence.class);
         assertSame(result.get(), string);
     }
 
     @Test
     public void safeCastRejectsInvalidCast() {
         Object object = new Object();
-        Result<CharSequence, ClassCastException> result = Result.safeCast(object, CharSequence.class);
+        Result<CharSequence> result = Result.safeCast(object, CharSequence.class);
         assertEquals(result.getException().getClass(), ClassCastException.class);
     }
 
     @Test
     public void safeCastAcceptsNull() {
-        Result<CharSequence, ClassCastException> result = Result.safeCast(null, CharSequence.class);
+        Result<CharSequence> result = Result.safeCast(null, CharSequence.class);
         assertNull(result.get());
     }
 }


### PR DESCRIPTION
Including the Throwable type in the generic signature complicated the library without adding any real benefit. This PR removes the <ERR> generic argument from all classes and methods.